### PR TITLE
Update Docker.class.php to fix FileInfo Error

### DIFF
--- a/src/includes/Docker.class.php
+++ b/src/includes/Docker.class.php
@@ -578,8 +578,8 @@ class Container {
                 'File' => $file['full_path'],
                 'InArchive' => $file['r_path'],
                 'Permissions' => substr(sprintf('%o', fileperms($file['full_path'])), -4),
-                'User' => posix_getpwuid(fileowner($file['full_path']))['name'],
-                'Group' => posix_getgrgid(filegroup($file['full_path']))['name']
+                'User' => posix_getpwuid(fileowner($file['full_path']))['name'] ?? null,
+                'Group' => posix_getgrgid(filegroup($file['full_path']))['name'] ?? null
             ];
     
         }


### PR DESCRIPTION
I added `?? null` to the end of the "User" and "Group" value get commands, to account for when it sometimes cannot get those values.